### PR TITLE
Support for having blank management VM resource ID

### DIFF
--- a/research-spoke/main.bicep
+++ b/research-spoke/main.bicep
@@ -64,9 +64,9 @@ param createPolicyExemptions bool = false
 param policyAssignmentId string = ''
 
 @secure()
-param sessionHostLocalAdminUsername string
+param sessionHostLocalAdminUsername string = ''
 @secure()
-param sessionHostLocalAdminPassword string
+param sessionHostLocalAdminPassword string = ''
 @description('Specifies if logons to virtual machines should use AD or Entra ID.')
 @allowed(['ad', 'entraID'])
 param logonType string
@@ -381,10 +381,9 @@ module diskEncryptionSetModule '../shared-modules/security/diskEncryptionSet.bic
   dependsOn: [uamiKvRbacModule]
 }
 
-// TODO: Split once into var and re-use var
-var hubManagementVmSubscriptionId = split(hubManagementVmId, '/')[2]
-var hubManagementVmResourceGroupName = split(hubManagementVmId, '/')[4]
-var hubManagementVmName = split(hubManagementVmId, '/')[8]
+var hubManagementVmSubscriptionId = !empty(hubManagementVmId) ? split(hubManagementVmId, '/')[2] : ''
+var hubManagementVmResourceGroupName = !empty(hubManagementVmId) ? split(hubManagementVmId, '/')[4] : ''
+var hubManagementVmName = !empty(hubManagementVmId) ? split(hubManagementVmId, '/')[8] : ''
 
 import { roleAssignmentType } from '../shared-modules/types/roleAssignment.bicep'
 

--- a/research-spoke/spoke-modules/storage/main.bicep
+++ b/research-spoke/spoke-modules/storage/main.bicep
@@ -155,7 +155,7 @@ module storageAccountModule 'storageAccount.bicep' = {
   }
 }
 
-resource hubManagementRg 'Microsoft.Resources/resourceGroups@2024-03-01' existing = {
+resource hubManagementRg 'Microsoft.Resources/resourceGroups@2024-03-01' existing = if (domainJoin && length(fileShareNames) > 0) {
   name: hubManagementRgName
   scope: subscription(hubSubscriptionId)
 }


### PR DESCRIPTION
Optional when not using AD as the logon type.

Also closes #153.