### PR TITLE
Adding read access to export-review share for honest broker

### DIFF
--- a/research-spoke/main.bicep
+++ b/research-spoke/main.bicep
@@ -485,12 +485,6 @@ var storageAccountReaderRoleAssignmentForResearcherGroup = {
   description: 'Read access to the storage account is required to use Azure Storage Explorer.'
 }
 
-// [Add for honestBrokerEntraIdObjectId]
-var storageAccountReaderRoleAssignmentForHonestBrokerGroup = {
-  roleDefinitionId: rolesModule.outputs.roles.Reader
-  principalId: honestBrokerEntraIdObjectId
-  description: 'Read access to the storage account is required to use Azure Storage Explorer.'
-}
 
 // Deploy the project's private storage account
 module storageModule './spoke-modules/storage/main.bicep' = {
@@ -680,9 +674,6 @@ module airlockModule './spoke-modules/airlock/main.bicep' = {
     // TODO: Refactor
     honestBrokerEntraObjectId: honestBrokerEntraIdObjectId
     honestBrokerRoleDefinitionId: rolesModule.outputs.roles.StorageFileDataSMBShareReader
-    airlockStorageAccountRoleAssignments: [
-      storageAccountReaderRoleAssignmentForHonestBrokerGroup
-    ]
 
     deploymentNameStructure: deploymentNameStructure
     namingConvention: namingConvention

--- a/research-spoke/main.bicep
+++ b/research-spoke/main.bicep
@@ -609,7 +609,7 @@ module vdiModule '../shared-modules/virtualDesktop/main.bicep' = if (useSessionH
     logonType: logonType
     namingStructure: replace(namingStructure, '{subWorkloadName}', 'avd')
     roles: rolesModule.outputs.roles
-    userObjectId: [
+    userObjectIds: [
       researcherEntraIdObjectId
       honestBrokerEntraIdObjectId
     ]

--- a/research-spoke/spoke-modules/airlock/main.bicep
+++ b/research-spoke/spoke-modules/airlock/main.bicep
@@ -19,7 +19,6 @@ param researcherAadObjectId string
 
 param honestBrokerEntraObjectId string
 param honestBrokerRoleDefinitionId string
-param airlockStorageAccountRoleAssignments roleAssignmentType
 
 @description('The names of the ingest and exportApproved containers in the public storage account; and exportRequest in the private storage account.')
 param containerNames object = {
@@ -167,9 +166,7 @@ module spokeAirlockStorageAccountModule '../storage/main.bicep' = if (!useCentra
     uamiPrincipalId: hubManagementVmUamiPrincipalId
     uamiClientId: hubManagementVmUamiClientId
     roles: roles
-
-    storageAccountRoleAssignments: airlockStorageAccountRoleAssignments
-    
+ 
     // The airlock storage uses file shares via ADF, so access keys are used
     allowSharedKeyAccess: true
   }

--- a/shared-modules/virtualDesktop/avd.bicep
+++ b/shared-modules/virtualDesktop/avd.bicep
@@ -6,7 +6,7 @@ param workspaceFriendlyName string
 param remoteAppApplicationGroupInfo remoteAppApplicationGroup[] = []
 
 @description('Entra ID object ID of the user or group to be assigned to the Desktop Virtualization User (dvu) role.')
-param userObjectId string[] = []
+param userObjectIds string[] = []
 
 @description('Entra ID object ID of the user or group to be assigned to the Virtual Machine Administrator Login (vmal) role, if using Entra ID join.')
 param adminObjectId string
@@ -128,11 +128,11 @@ resource desktopApplicationGroup 'Microsoft.DesktopVirtualization/applicationGro
 
 // Create a role assignment for the user or group to be assigned to the Virtual Machine User Login (vmul) role, if using Entra ID join
 resource rgRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
-  for userId in userObjectId: if (logonType == 'entraID') {
-    name: guid(resourceGroup().id, userId, roles.VirtualMachineUserLogin)
+  for userObjectId in userObjectIds: if (logonType == 'entraID') {
+    name: guid(resourceGroup().id, userObjectId, roles.VirtualMachineUserLogin)
     properties: {
       roleDefinitionId: roles.VirtualMachineUserLogin
-      principalId: userId
+      principalId: userObjectId
     }
   }
 ]
@@ -150,12 +150,12 @@ resource rgAdminRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
 // LATER: Execute deployment script for Update-AzWvdDesktop -ResourceGroupName resourceGroup().name -ApplicationGroupName desktopApplicationGroup.name -Name SessionDesktop -FriendlyName desktopAppGroupFriendlyName
 
 resource dagUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
-  for userId in userObjectId: if (logonType == 'entraID') {
-    name: guid(desktopApplicationGroup.id, userId, roles.DesktopVirtualizationUser)
+  for userObjectId in userObjectIds: if (logonType == 'entraID') {
+    name: guid(desktopApplicationGroup.id, userObjectId, roles.DesktopVirtualizationUser)
     scope: desktopApplicationGroup
     properties: {
       roleDefinitionId: roles.DesktopVirtualizationUser
-      principalId: userId
+      principalId: userObjectId
     }
   }
 ]
@@ -187,7 +187,7 @@ module remoteAppApplicationGroupsModule 'remoteAppApplicationGroup.bicep' = [
       friendlyName: appGroup.friendlyName
       hostPoolId: hostPool.id
 
-      principalId: userObjectId
+      principalId: userObjectIds
       roleDefinitionId: roles.DesktopVirtualizationUser
     }
   }

--- a/shared-modules/virtualDesktop/avd.bicep
+++ b/shared-modules/virtualDesktop/avd.bicep
@@ -187,7 +187,7 @@ module remoteAppApplicationGroupsModule 'remoteAppApplicationGroup.bicep' = [
       friendlyName: appGroup.friendlyName
       hostPoolId: hostPool.id
 
-      principalId: userObjectIds
+      principalObjectIds: userObjectIds
       roleDefinitionId: roles.DesktopVirtualizationUser
     }
   }

--- a/shared-modules/virtualDesktop/avd.bicep
+++ b/shared-modules/virtualDesktop/avd.bicep
@@ -6,7 +6,7 @@ param workspaceFriendlyName string
 param remoteAppApplicationGroupInfo remoteAppApplicationGroup[] = []
 
 @description('Entra ID object ID of the user or group to be assigned to the Desktop Virtualization User (dvu) role.')
-param userObjectId string = ''
+param userObjectId string[] = []
 
 @description('Entra ID object ID of the user or group to be assigned to the Virtual Machine Administrator Login (vmal) role, if using Entra ID join.')
 param adminObjectId string
@@ -127,14 +127,15 @@ resource desktopApplicationGroup 'Microsoft.DesktopVirtualization/applicationGro
   }
 
 // Create a role assignment for the user or group to be assigned to the Virtual Machine User Login (vmul) role, if using Entra ID join
-resource rgRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' =
-  if (logonType == 'entraID' && !empty(userObjectId)) {
-    name: guid(resourceGroup().id, userObjectId, roles.VirtualMachineUserLogin)
+resource rgRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for userId in userObjectId: if (logonType == 'entraID') {
+    name: guid(resourceGroup().id, userId, roles.VirtualMachineUserLogin)
     properties: {
       roleDefinitionId: roles.VirtualMachineUserLogin
-      principalId: userObjectId
+      principalId: userId
     }
   }
+]
 
 // Create a role assignment for the admins to be assigned to the Virtual Machine Administrator Login (vmal) role, if using Entra ID join
 resource rgAdminRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' =
@@ -148,15 +149,16 @@ resource rgAdminRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
 
 // LATER: Execute deployment script for Update-AzWvdDesktop -ResourceGroupName resourceGroup().name -ApplicationGroupName desktopApplicationGroup.name -Name SessionDesktop -FriendlyName desktopAppGroupFriendlyName
 
-resource dagUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' =
-  if (deployDesktopAppGroup && !empty(userObjectId)) {
-    name: guid(desktopApplicationGroup.id, userObjectId, roles.DesktopVirtualizationUser)
+resource dagUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for userId in userObjectId: if (logonType == 'entraID') {
+    name: guid(desktopApplicationGroup.id, userId, roles.DesktopVirtualizationUser)
     scope: desktopApplicationGroup
     properties: {
       roleDefinitionId: roles.DesktopVirtualizationUser
-      principalId: userObjectId
+      principalId: userId
     }
   }
+]
 
 // TODO: Role assignment for admins required?
 // resource dagAdminRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [

--- a/shared-modules/virtualDesktop/main.bicep
+++ b/shared-modules/virtualDesktop/main.bicep
@@ -3,7 +3,7 @@ targetScope = 'subscription'
 param resourceGroupName string
 
 param adminObjectId string
-param userObjectId string
+param userObjectId string[]
 param deploymentNameStructure string
 param desktopAppGroupFriendlyName string
 param logonType string

--- a/shared-modules/virtualDesktop/main.bicep
+++ b/shared-modules/virtualDesktop/main.bicep
@@ -3,7 +3,7 @@ targetScope = 'subscription'
 param resourceGroupName string
 
 param adminObjectId string
-param userObjectId string[]
+param userObjectIds string[]
 param deploymentNameStructure string
 param desktopAppGroupFriendlyName string
 param logonType string
@@ -66,7 +66,7 @@ module avdModule 'avd.bicep' = {
     tags: tags
     workspaceFriendlyName: workspaceFriendlyName
     usePrivateLinkForHostPool: usePrivateLinkForHostPool
-    userObjectId: userObjectId
+    userObjectIds: userObjectIds
   }
 }
 

--- a/shared-modules/virtualDesktop/remoteAppApplicationGroup.bicep
+++ b/shared-modules/virtualDesktop/remoteAppApplicationGroup.bicep
@@ -5,7 +5,7 @@ param friendlyName string
 param applications array
 param tags object
 
-param principalId string
+param principalId string[]
 param roleDefinitionId string
 
 /*
@@ -64,15 +64,15 @@ resource remoteApplications 'Microsoft.DesktopVirtualization/applicationGroups/a
 ]
 
 // Assign the specified role to the specified principal
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' =
-  if (!empty(principalId) && !empty(roleDefinitionId)) {
-    name: guid(applicationGroup.id, principalId, roleDefinitionId)
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for userId in principalId: if (!empty(roleDefinitionId)) {
+    name: guid(applicationGroup.id, userId, roleDefinitionId)
     scope: applicationGroup
     properties: {
       roleDefinitionId: roleDefinitionId
-      principalId: principalId
+      principalId: userId
     }
-  }
+  }]
 
 output id string = applicationGroup.id
 output name string = applicationGroup.name

--- a/shared-modules/virtualDesktop/remoteAppApplicationGroup.bicep
+++ b/shared-modules/virtualDesktop/remoteAppApplicationGroup.bicep
@@ -5,7 +5,7 @@ param friendlyName string
 param applications array
 param tags object
 
-param principalId string[]
+param principalObjectIds string[]
 param roleDefinitionId string
 
 /*
@@ -65,12 +65,12 @@ resource remoteApplications 'Microsoft.DesktopVirtualization/applicationGroups/a
 
 // Assign the specified role to the specified principal
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
-  for userId in principalId: if (!empty(roleDefinitionId)) {
-    name: guid(applicationGroup.id, userId, roleDefinitionId)
+  for principleObjectId in principalObjectIds: if (!empty(roleDefinitionId)) {
+    name: guid(applicationGroup.id, principleObjectId, roleDefinitionId)
     scope: applicationGroup
     properties: {
       roleDefinitionId: roleDefinitionId
-      principalId: userId
+      principalId: principleObjectId
     }
   }]
 


### PR DESCRIPTION
Added parameters to specify `honestBrokerEntraObjectId` and role assignments for airlock storage account in research spoke.

The following `main.bicepparam` file was used:

```Bicep
using './main.bicep'
param sequence = 10

// For interactive deployments, replace <value> with the results of
// $(iwr 'https://ipecho.net/plain').Content
var myIpAddress = '<value>'

param debugMode = false
param debugRemoteIp = myIpAddress
param debugPrincipalId = ''

param publicStorageAccountAllowedIPs = [myIpAddress]

// Set these values based on the output of the hub deployment
param hubFirewallIp = '<value>'
param hubVNetResourceId = '<value>'
param hubPrivateDnsZonesResourceGroupId = '<value>'
//

param location = '<value>'
param workloadName = 'ResPrjA'
param environment = 'demo'
param tags = {environment: 'demo'}

param namingConvention = '{workloadName}-{subWorkloadName}-{env}-{rtype}-{loc}-{seq}'

param networkAddressSpaces = ['10.1.${sequence + 1}.0/24']
param customDnsIps = []

param researcherEntraIdObjectId = '<value>'

# NB, New parameter used
param honestBrokerEntraIdObjectId = '<value>'

param adminEntraIdObjectId = '<value>'
param logonType = 'entraID'

param filesIdentityType = logonType == 'entraID' ? 'AADKERB' : 'None'

param desktopAppGroupFriendlyName = 'Research Spoke: ${workloadName} ${sequence}'
param workspaceFriendlyName = 'Research Spoke: ${workloadName} ${sequence}'
param useSessionHostAsResearchVm = true
param sessionHostCount = 1


// Because Research VMs are AVD session hosts in the spoke, the following are required.
param sessionHostLocalAdminUsername = 'srvadmin'
param sessionHostLocalAdminPassword = '<value>'

param sessionHostSize = 'Standard_D2as_v5'

// Optional filter to ignore files without the extensions listed when placed into the ingest blob container.
param allowedIngestFileExtensions = ['.zip', '.tar.gz']

param airlockApproverEmail = '<value>'

param isAirlockReviewCentralized = false
// Leave the next three parameter values empty if not using a centralized airlock review
param centralAirlockFileShareName = ''
param centralAirlockKeyVaultId = ''
param centralAirlockStorageAccountId = ''

// Because, sys.utcnow() Bicep function is not idempotent across deployments
// run the following snippet in Powershell to set the value:
//     Get-Date (Get-Date).ToUniversalTime() -UFormat '+%Y-%m-%dT%H:%M:%SZ' 
param encryptionKeyExpirySeed = '<value>'
```