### PR TITLE
Deploy NAT Gateway V2 for Azure Firewall egress

### DIFF
--- a/research-hub/hub-modules/networking/main.bicep
+++ b/research-hub/hub-modules/networking/main.bicep
@@ -109,7 +109,7 @@ module firewallNatGatewayModule 'br/public:avm/res/network/nat-gateway:2.1.0' = 
     natGatewaySku: 'StandardV2'
     publicIPAddresses: [
       {
-        name: replace(resourceNamingStructure, '{rtype}', 'pip-fw-nat')
+        name: replace(resourceNamingStructure, '{rtype}', 'pip-ng-fw')
         skuName: 'StandardV2'
       }
     ]

--- a/research-hub/hub-modules/networking/main.bicep
+++ b/research-hub/hub-modules/networking/main.bicep
@@ -45,6 +45,7 @@ param tags object
 param deploymentTime string
 param deploymentNameStructure string
 param resourceNamingStructure string
+param enableAvmTelemetry bool = true
 @description('The resource naming structure to use for IP Group resources. For ease of use when creating firewall rules, it is useful to change the order of the segments. Optional; defaults to resourceNamingStructure.')
 param ipGroupNamingStructure string = resourceNamingStructure
 
@@ -100,6 +101,32 @@ var createManagementIPConfiguration = (firewallTier == 'Basic' || firewallForced
 // TODO: Replace the {{nvaIPAddress}} placeholder with the upstream NVA's IP address
 var AzureFirewallSubnetRoutes = firewallForcedTunnel ? [] : loadJsonContent('./routes/AzureFirewallNormal.jsonc')
 
+module firewallNatGatewayModule 'br/public:avm/res/network/nat-gateway:2.1.0' = if (!firewallForcedTunnel) {
+  name: take(replace(deploymentNameStructure, '{rtype}', 'ng-fw'), 64)
+  params: {
+    name: replace(resourceNamingStructure, '{rtype}', 'ng-fw')
+    availabilityZone: -1
+    natGatewaySku: 'StandardV2'
+    publicIPAddresses: [
+      {
+        name: replace(resourceNamingStructure, '{rtype}', 'pip-fw-nat')
+        skuName: 'StandardV2'
+      }
+    ]
+    location: location
+    tags: tags
+    enableTelemetry: enableAvmTelemetry
+  }
+}
+
+var firewallSubnetNatGatewayAssociation = firewallForcedTunnel
+  ? {}
+  : {
+      natGateway: {
+        id: firewallNatGatewayModule!.outputs.resourceId
+      }
+    }
+
 // Variable to hold the subnets that are always required, regardless of optional components
 var requiredSubnets = {
   DataSubnet: {
@@ -109,13 +136,16 @@ var requiredSubnets = {
     delegation: ''
     addressPrefix: cidrSubnet(networkAddressSpace, 27, 4) // The fifth /27
   }
-  AzureFirewallSubnet: {
-    serviceEndpoints: []
-    routes: AzureFirewallSubnetRoutes
-    //securityRules: [] Azure Firewall does not support NSGs on its subnets
-    delegation: ''
-    addressPrefix: cidrSubnet(networkAddressSpace, 26, 0) // The first /26
-  }
+  AzureFirewallSubnet: union(
+    {
+      serviceEndpoints: []
+      routes: AzureFirewallSubnetRoutes
+      //securityRules: [] Azure Firewall does not support NSGs on its subnets
+      delegation: ''
+      addressPrefix: cidrSubnet(networkAddressSpace, 26, 0) // The first /26
+    },
+    firewallSubnetNatGatewayAssociation
+  )
 }
 
 var AzureFirewallManagementSubnet = createManagementIPConfiguration

--- a/research-hub/main.bicep
+++ b/research-hub/main.bicep
@@ -284,6 +284,7 @@ module networkModule 'hub-modules/networking/main.bicep' = {
     ipGroupNamingStructure: ipGroupNamingStructure
 
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
+    enableAvmTelemetry: enableAvmTelemetry
   }
 }
 

--- a/shared-modules/networking/main.bicep
+++ b/shared-modules/networking/main.bicep
@@ -16,8 +16,9 @@ param location string
     securityRules: array (optional; if ommitted, no NSG will be created. If [], a default NSG will be created.)
     routes: array (optional; if ommitted, no route table will be created. If [], an empty route table will be created.)
     delegation: string (optional, can be ommitted or be empty string)
+    natGateway: object (optional; an ARM resource reference containing the NAT Gateway resource ID)
   } */
-@description('A custom object defining the subnet properties of each subnet. { subnet-name: { addressPrefix: string, serviceEndpoints: [], securityRules: [], routes: [], delegation: string } }')
+@description('A custom object defining the subnet properties of each subnet. { subnet-name: { addressPrefix: string, serviceEndpoints: [], securityRules: [], routes: [], delegation: string, natGateway: { id: string } } }')
 param subnetDefs object
 @description('The definition of additional subnets that have been manually created. Uses the ARM schema for subnets.')
 param additionalSubnets array = []

--- a/shared-modules/networking/main.bicep
+++ b/shared-modules/networking/main.bicep
@@ -16,7 +16,7 @@ param location string
     securityRules: array (optional; if ommitted, no NSG will be created. If [], a default NSG will be created.)
     routes: array (optional; if ommitted, no route table will be created. If [], an empty route table will be created.)
     delegation: string (optional, can be ommitted or be empty string)
-    natGateway: object (optional; an ARM resource reference containing the NAT Gateway resource ID)
+    natGateway: { id: string } (optional; an ARM resource reference containing the NAT Gateway resource ID)
   } */
 @description('A custom object defining the subnet properties of each subnet. { subnet-name: { addressPrefix: string, serviceEndpoints: [], securityRules: [], routes: [], delegation: string, natGateway: { id: string } } }')
 param subnetDefs object

--- a/shared-modules/networking/vnet.bicep
+++ b/shared-modules/networking/vnet.bicep
@@ -1,6 +1,6 @@
 param location string
 param vnetName string
-@description('The custom oject definition for the subnets. The key is the name of the subnet. The value is an object containing the properties for the subnet. { subnet-name: { addressPrefix: subnet-address-prefix, ... }, ... }')
+@description('The custom object definition for the subnets. The key is the name of the subnet. The value is an object containing the properties for the subnet. { subnet-name: { addressPrefix: subnet-address-prefix, natGateway: { id: nat-gateway-resource-id }, ... }, ... }')
 param subnetDefs object
 @minLength(1)
 param vnetAddressPrefixes array
@@ -53,6 +53,7 @@ var subnetArmDefs = [
       privateLinkServiceNetworkPolicies: contains(subnet.value, 'privateLinkServiceNetworkPolicies') && !empty(subnet.value.privateLinkServiceNetworkPolicies)
         ? subnet.value.privateLinkServiceNetworkPolicies
         : null
+      natGateway: contains(subnet.value, 'natGateway') ? subnet.value.natGateway : null
     }
   }
 ]

--- a/shared-modules/networking/vnet.bicep
+++ b/shared-modules/networking/vnet.bicep
@@ -53,7 +53,7 @@ var subnetArmDefs = [
       privateLinkServiceNetworkPolicies: contains(subnet.value, 'privateLinkServiceNetworkPolicies') && !empty(subnet.value.privateLinkServiceNetworkPolicies)
         ? subnet.value.privateLinkServiceNetworkPolicies
         : null
-      natGateway: contains(subnet.value, 'natGateway') ? subnet.value.natGateway : null
+      natGateway: contains(subnet.value, 'natGateway') && !empty(subnet.value.natGateway) ? subnet.value.natGateway : null
     }
   }
 ]


### PR DESCRIPTION
Azure Firewall currently handles outbound SNAT with its own public IP resources. This adds zone-redundant, scalable outbound connectivity while preserving the firewall public IP for inbound DNAT, health probes, and management traffic.

## Summary

- Deploy `br/public:avm/res/network/nat-gateway:2.1.0` with the `StandardV2` SKU and a module-managed StandardV2 IPv4 public IP.
- Associate the NAT Gateway with `AzureFirewallSubnet` for normal internet egress.
- Omit the NAT Gateway when forced tunneling sends egress to an upstream NVA.
- Extend the shared subnet contract for optional NAT Gateway associations and honor the existing AVM telemetry setting.

## Validation

- `az bicep build --file research-hub\main.bicep --stdout`
- `az bicep build-params --file research-hub\main.sample-aad.bicepparam --stdout`

Fixes: #231