### PR TITLE
Deploy all subnets as private subnets

### DIFF
--- a/shared-modules/networking/vnet.bicep
+++ b/shared-modules/networking/vnet.bicep
@@ -57,10 +57,16 @@ var subnetArmDefs = [
   }
 ]
 
-// Combine the subnets created/managed by this template with any additional subnets provided as a parameter
-var allSubnets = union(additionalSubnets, subnetArmDefs)
+// Combine all subnet sources and ensure every subnet is deployed without default outbound access
+var allSubnets = [
+  for subnet in union(additionalSubnets, subnetArmDefs): union(subnet, {
+    properties: union(subnet.properties, {
+      defaultOutboundAccess: false
+    })
+  })
+]
 
-resource vnet 'Microsoft.Network/virtualNetworks@2022-05-01' = {
+resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   name: vnetName
   location: location
   properties: {
@@ -82,7 +88,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2022-05-01' = {
 // Retrieve the subnets as an array of existing resources
 // This is important because we need to ensure subnet return value is matched to the name of the subnet correctly - order matters
 // This works because the parent property is set to the virtual network, which means this won't be attempted until the VNet is created
-resource subnetRes 'Microsoft.Network/virtualNetworks/subnets@2022-05-01' existing = [
+resource subnetRes 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' existing = [
   for subnet in subnetDefsArray: {
     name: subnet.key
     parent: vnet


### PR DESCRIPTION
Azure currently permits implicit default outbound connectivity because subnet definitions omit the private subnet setting. This change enforces private subnets centrally so hub, spoke, image-builder, and caller-supplied additional subnets follow the same secure default.

## Changes

- Normalize the combined subnet array and force `defaultOutboundAccess: false` while preserving existing subnet properties.
- Update the virtual network and subnet resource API versions to `2024-05-01` for schema support.

## Validation

- Compiled the shared VNet module and the research hub and spoke entry-point templates.
- Confirmed the generated ARM expression covers both generated and additional subnet definitions.

Fixes: #227